### PR TITLE
Update .travis.yml: Update node versions

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
 node_js:
+  - "5"
   - "4"
-  - "0.12"
-  - "0.10"
 branches:
   only:
     - master
 sudo: false
 script: npm test
+matrix:
+  allow_failures:
+    - node_js: "5"


### PR DESCRIPTION
Also default to allowing failures on node v5,
due to it having breaking changes, and node v4 being LTS